### PR TITLE
chore: adds a .gitignore file and removes desktop.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore system files
+desktop.ini
+Thumbs.db
+.DS_Store

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,6 +1,0 @@
-[.ShellClassInfo]
-IconResource=C:\WINDOWS\System32\SHELL32.dll,91
-[ViewState]
-Mode=
-Vid=
-FolderType=Generic


### PR DESCRIPTION
This will make it so that you can't accidentally add system-generated files to the repo.